### PR TITLE
Add HPA for Selenosis pods

### DIFF
--- a/05-selenosis-hpa.yaml
+++ b/05-selenosis-hpa.yaml
@@ -1,0 +1,26 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: selenosis
+  namespace: selenosis
+spec:
+  maxReplicas: 10
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: selenosis
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 30

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ If you need UI for your tests perform command
  kubectl apply -f 04-selenoid-ui.yaml
  ```
 
+ ## Deploy selenosis hpa
+ ```bash
+ kubectl apply -f 05-selenosis-hpa.yaml
+ ```
+
   ### Check deployment status
  ```bash
 kubectl get po -n selenosis


### PR DESCRIPTION
Adds an HPA that will scale the Selenosis pods between 2 and 10 pods based on the average CPU utilization across all pods. If the average is above 60%, the HPA will create more replicas of the Selenosis pods. 

Adds a scaledown behavior that prevents the HPA from scaling up and down too quickly. Since tests often take a bit of time to complete, scaling down too early may result in the HPA needing to scale up again once the tests execute. Adding a stabilization window prevents this. Also adds a percentage scaledown value so that not all pods are removed at once, instead removing 50% per 30 second iteration.