### PR TITLE
Update rbac.authorization.k8s.io version

### DIFF
--- a/01-namespace.yaml
+++ b/01-namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: selenosis
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   namespace: selenosis
@@ -13,7 +13,7 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: selenosis


### PR DESCRIPTION
The version rbac.authorization.k8s.io/v1beta1 is unavailable, so without this change the scripts did not deploy the solution fully.