### PR TITLE
Helm enhancements

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,9 @@ jobs:
             cd ..
           fi
 
+          # Copy the packaged chart to gh-pages directory
+          cp ${{ env.CHART_PACKAGE }} gh-pages/
+
           cd gh-pages
 
           # Configure git
@@ -67,17 +70,19 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
           # Create or update index
+          # Charts are served from GitHub Pages
+          REPO_URL="https://$(echo ${{ github.repository }} | cut -d'/' -f1).github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)"
           if [ -f index.yaml ]; then
-            helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}" --merge index.yaml
+            helm repo index . --url "$REPO_URL" --merge index.yaml
           else
-            helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
+            helm repo index . --url "$REPO_URL"
           fi
 
           # Commit and push if there are changes
-          git add index.yaml
+          git add .
           if ! git diff --quiet || ! git diff --staged --quiet; then
-            git commit -m "Update Helm repository index for ${{ github.ref_name }}"
+            git commit -m "Update Helm repository for ${{ github.ref_name }}"
             git push -u origin gh-pages
           else
-            echo "No changes to index.yaml"
+            echo "No changes to commit"
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,11 +31,33 @@ jobs:
       - name: Lint Chart
         run: helm lint .
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        with:
-          charts_dir: .
-          skip_packaging: false
+      - name: Package Chart
+        run: |
+          helm package . --destination .
+          echo "CHART_PACKAGE=$(ls selenosis-deploy-*.tgz)" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SKIP_EXISTING: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            "${{ env.CHART_PACKAGE }}" \
+            --title "Release ${{ github.ref_name }}" \
+            --generate-notes
+
+      - name: Update Helm Repository Index
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+          # Clone gh-pages branch
+          git clone --single-branch --branch gh-pages "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages || git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
+
+          cd gh-pages
+
+          # Create or update index
+          helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}" --merge index.yaml || helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
+
+          # Commit and push if there are changes
+          git add index.yaml
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Update Helm repository index for ${{ github.ref_name }}" && git push)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,41 @@
+name: Release Helm Chart
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Lint Chart
+        run: helm lint .
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: .
+          skip_packaging: false
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,17 +47,37 @@ jobs:
 
       - name: Update Helm Repository Index
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-          # Clone gh-pages branch
-          git clone --single-branch --branch gh-pages "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages || git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
+          # Try to clone gh-pages branch, or create it if it doesn't exist
+          if git clone --single-branch --branch gh-pages "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages 2>/dev/null; then
+            echo "gh-pages branch exists, updating..."
+          else
+            echo "gh-pages branch doesn't exist, creating..."
+            mkdir gh-pages
+            cd gh-pages
+            git init
+            git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+            git checkout -b gh-pages
+            cd ..
+          fi
 
           cd gh-pages
 
+          # Configure git
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
           # Create or update index
-          helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}" --merge index.yaml || helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
+          if [ -f index.yaml ]; then
+            helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}" --merge index.yaml
+          else
+            helm repo index . --url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
+          fi
 
           # Commit and push if there are changes
           git add index.yaml
-          git diff --quiet && git diff --staged --quiet || (git commit -m "Update Helm repository index for ${{ github.ref_name }}" && git push)
+          if ! git diff --quiet || ! git diff --staged --quiet; then
+            git commit -m "Update Helm repository index for ${{ github.ref_name }}"
+            git push -u origin gh-pages
+          else
+            echo "No changes to index.yaml"
+          fi

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: selenosis-deploy
 description: Helm chart to deploy Selenosis services (browser-controller, browser-service, selenosis, browser-ui)
 type: application
-version: 0.1.0
+version: 2.0.3
 appVersion: "develop"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,26 @@ This chart deploys the full Selenosis stack:
 CRDs for `Browser` and `BrowserConfig` are shipped in `crds/` and installed automatically.
 Each service is configurable via Helm values that map to the environment variables described in the individual project READMEs.
 
-## Install and first deploy
+## Installation
+
+### From Helm Repository
+
+Add the Selenosis Helm repository:
+
+```sh
+helm repo add selenosis https://alcounit.github.io/selenosis-deploy/
+helm repo update
+```
+
+Install the chart:
+
+```sh
+helm install selenosis selenosis/selenosis-deploy -n selenosis --create-namespace
+```
+
+### From Git Repository
+
+Clone and install directly:
 
 ```sh
 git clone https://github.com/alcounit/selenosis-deploy.git
@@ -67,3 +86,98 @@ Apply:
 ```sh
 helm upgrade --install selenosis . -n selenosis -f values.local.yaml
 ```
+
+## Ingress Configuration
+
+Expose services via Ingress for external access with TLS and WebSocket support.
+
+Each component (selenosis and browserUI) has its own ingress configuration under its respective section.
+
+### Basic Setup (NGINX Ingress Controller)
+
+```yaml
+selenosis:
+  ingress:
+    enabled: true
+    className: nginx
+    host: selenosis.example.com
+
+browserUI:
+  ingress:
+    enabled: true
+    className: nginx
+    host: ui.example.com
+    # CRITICAL: WebSocket support for VNC proxy
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/websocket-services: "browser-ui"
+```
+
+### With TLS/SSL Certificate
+
+```yaml
+selenosis:
+  ingress:
+    enabled: true
+    className: nginx
+    host: selenosis.example.com
+    annotations:
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    tls:
+      secretName: selenosis-tls
+
+browserUI:
+  ingress:
+    enabled: true
+    className: nginx
+    host: ui.example.com
+    annotations:
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/websocket-services: "browser-ui"
+    tls:
+      secretName: browser-ui-tls
+```
+
+**Important**: Browser UI requires WebSocket support for the VNC proxy. The above annotations are required for NGINX Ingress Controller. Other ingress controllers may require different annotations.
+
+Apply:
+
+```sh
+helm upgrade --install selenosis . -n selenosis -f ingress-values.yaml
+```
+
+## Maintainer Release Process
+
+To create a new chart release:
+
+1. Update `Chart.yaml` version:
+   ```yaml
+   version: 2.0.3
+   ```
+
+2. Commit and push:
+   ```sh
+   git add Chart.yaml
+   git commit -m "Bump chart version to 2.0.3"
+   git push
+   ```
+
+3. Create and push tag:
+   ```sh
+   git tag v2.0.3
+   git push origin v2.0.3
+   ```
+
+4. GitHub Actions will automatically:
+   - Lint and package the chart
+   - Create GitHub Release with chart tarball
+   - Publish to Helm repository (GitHub Pages)
+
+5. Users can now install the new version:
+   ```sh
+   helm repo update
+   helm upgrade selenosis selenosis/selenosis-deploy --version 2.0.3
+   ```

--- a/templates/browser-controller/deployment.yaml
+++ b/templates/browser-controller/deployment.yaml
@@ -24,6 +24,22 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
+
+      {{- with (.Values.browserController.nodeSelector | default .Values.common.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.browserController.tolerations | default .Values.common.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.browserController.affinity | default .Values.common.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       containers:
       - name: manager
         image: {{ .Values.browserController.image }}

--- a/templates/browser-controller/deployment.yaml
+++ b/templates/browser-controller/deployment.yaml
@@ -25,17 +25,17 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserController.nodeSelector | default .Values.common.nodeSelector) }}
+      {{- with (.Values.browserController.nodeSelector | default .Values.global.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserController.tolerations | default .Values.common.tolerations) }}
+      {{- with (.Values.browserController.tolerations | default .Values.global.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserController.affinity | default .Values.common.affinity) }}
+      {{- with (.Values.browserController.affinity | default .Values.global.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/browser-service/deployment.yaml
+++ b/templates/browser-service/deployment.yaml
@@ -24,6 +24,22 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
+
+      {{- with (.Values.browserService.nodeSelector | default .Values.common.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.browserService.tolerations | default .Values.common.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.browserService.affinity | default .Values.common.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       containers:
       - name: browser-service
         image: {{ .Values.browserService.image }}

--- a/templates/browser-service/deployment.yaml
+++ b/templates/browser-service/deployment.yaml
@@ -25,17 +25,17 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserService.nodeSelector | default .Values.common.nodeSelector) }}
+      {{- with (.Values.browserService.nodeSelector | default .Values.global.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserService.tolerations | default .Values.common.tolerations) }}
+      {{- with (.Values.browserService.tolerations | default .Values.global.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserService.affinity | default .Values.common.affinity) }}
+      {{- with (.Values.browserService.affinity | default .Values.global.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/browser-ui/deployment.yaml
+++ b/templates/browser-ui/deployment.yaml
@@ -25,6 +25,22 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
+
+      {{- with (.Values.browserUI.nodeSelector | default .Values.common.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.browserUI.tolerations | default .Values.common.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.browserUI.affinity | default .Values.common.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       containers:
       - name: browser-ui
         image: {{ .Values.browserUI.image }}

--- a/templates/browser-ui/deployment.yaml
+++ b/templates/browser-ui/deployment.yaml
@@ -26,17 +26,17 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserUI.nodeSelector | default .Values.common.nodeSelector) }}
+      {{- with (.Values.browserUI.nodeSelector | default .Values.global.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserUI.tolerations | default .Values.common.tolerations) }}
+      {{- with (.Values.browserUI.tolerations | default .Values.global.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.browserUI.affinity | default .Values.common.affinity) }}
+      {{- with (.Values.browserUI.affinity | default .Values.global.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/browser-ui/ingress.yaml
+++ b/templates/browser-ui/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.browserUI.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "selenosis-deploy.componentName" (dict "root" . "component" "browser-ui") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "selenosis-deploy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: browser-ui
+  {{- with .Values.browserUI.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.browserUI.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+
+  {{- if .Values.browserUI.ingress.tls }}
+  tls:
+    {{- if kindIs "slice" .Values.browserUI.ingress.tls }}
+    {{- toYaml .Values.browserUI.ingress.tls | nindent 4 }}
+    {{- else }}
+    - secretName: {{ .Values.browserUI.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.browserUI.ingress.host }}
+    {{- end }}
+  {{- end }}
+
+  rules:
+  - host: {{ .Values.browserUI.ingress.host | quote }}
+    http:
+      paths:
+      - path: {{ .Values.browserUI.ingress.path | default "/" }}
+        pathType: {{ .Values.browserUI.ingress.pathType | default "Prefix" }}
+        backend:
+          service:
+            name: {{ include "selenosis-deploy.componentName" (dict "root" . "component" "browser-ui") }}
+            port:
+              number: {{ .Values.browserUI.service.port }}
+{{- end }}

--- a/templates/selenosis/deployment.yaml
+++ b/templates/selenosis/deployment.yaml
@@ -25,6 +25,22 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
+
+      {{- with (.Values.selenosis.nodeSelector | default .Values.common.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.selenosis.tolerations | default .Values.common.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (.Values.selenosis.affinity | default .Values.common.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       containers:
       - name: selenosis
         image: {{ .Values.selenosis.image }}

--- a/templates/selenosis/deployment.yaml
+++ b/templates/selenosis/deployment.yaml
@@ -26,17 +26,17 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.selenosis.nodeSelector | default .Values.common.nodeSelector) }}
+      {{- with (.Values.selenosis.nodeSelector | default .Values.global.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.selenosis.tolerations | default .Values.common.tolerations) }}
+      {{- with (.Values.selenosis.tolerations | default .Values.global.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (.Values.selenosis.affinity | default .Values.common.affinity) }}
+      {{- with (.Values.selenosis.affinity | default .Values.global.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/selenosis/ingress.yaml
+++ b/templates/selenosis/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.selenosis.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "selenosis-deploy.componentName" (dict "root" . "component" "selenosis") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "selenosis-deploy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: selenosis
+  {{- with .Values.selenosis.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.selenosis.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+
+  {{- if .Values.selenosis.ingress.tls }}
+  tls:
+    {{- if kindIs "slice" .Values.selenosis.ingress.tls }}
+    {{- toYaml .Values.selenosis.ingress.tls | nindent 4 }}
+    {{- else }}
+    - secretName: {{ .Values.selenosis.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.selenosis.ingress.host }}
+    {{- end }}
+  {{- end }}
+
+  rules:
+  - host: {{ .Values.selenosis.ingress.host | quote }}
+    http:
+      paths:
+      - path: {{ .Values.selenosis.ingress.path | default "/" }}
+        pathType: {{ .Values.selenosis.ingress.pathType | default "Prefix" }}
+        backend:
+          service:
+            name: {{ include "selenosis-deploy.componentName" (dict "root" . "component" "selenosis") }}
+            port:
+              number: {{ .Values.selenosis.service.port }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -4,8 +4,6 @@ fullnameOverride: ""
 global:
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
-
-common:
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,11 @@ global:
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
 
+common:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 browserController:
   enabled: true
   image: alcounit/browser-controller:v0.0.5
@@ -24,6 +29,10 @@ browserController:
     limits:
       cpu: "500m"
       memory: "128Mi"
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 browserService:
   enabled: true
@@ -46,6 +55,10 @@ browserService:
     limits:
       cpu: "500m"
       memory: "256Mi"
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 selenosis:
   enabled: true
@@ -72,6 +85,23 @@ selenosis:
       cpu: "500m"
       memory: "256Mi"
 
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  ingress:
+    enabled: false
+    className: "nginx"
+    host: "selenosis.example.com"
+    path: "/"
+    pathType: Prefix
+    annotations: {}
+    #   nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    #   nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    #   cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+    tls: {}
+
 browserUI:
   enabled: true
   image: alcounit/browser-ui:v0.0.4
@@ -92,3 +122,23 @@ browserUI:
     limits:
       cpu: "500m"
       memory: "256Mi"
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  ingress:
+    enabled: false
+    className: "nginx"
+    host: "ui.example.com"
+    path: "/"
+    pathType: Prefix
+    # CRITICAL: WebSocket annotations required for VNC proxy
+    annotations: {}
+    # Example annotations for NGINX (WebSocket support):
+    # annotations:
+    #   nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    #   nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    #   nginx.ingress.kubernetes.io/websocket-services: "browser-ui"
+    #   cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    tls: {}


### PR DESCRIPTION
Changes:
*  Automated Releases
  - GitHub Actions workflow for automated chart packaging and publishing
  - Automatic Helm repository (GitHub Pages) index updates on tag push
* Ingress Support
  - Ingress templates for Selenosis and Browser UI services
  - TLS/SSL configuration support
  - WebSocket annotations for Browser UI VNC proxy
  - Configurable ingress classes and custom annotations
* Pod Scheduling
  - nodeSelector, tolerations, and affinity support for all deployments
  - Per-component and common scheduling configuration
* Documentation
  - Installation from Helm repository instructions
  - Maintainer release process guide
* Chart version: 0.1.0 → 2.0.3

@alcounit please, review it carefully. I'd like to see it to deploy on our infrastructure
If you accept this change, you'll need to enable GH pages to host index.yaml